### PR TITLE
Support concurrent rate-type in argument multiplex

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -74,7 +74,7 @@
             "args": [
                 "guidellm_rate_type"
             ],
-            "vals": "sweep|synchronous|throughput|constant|poisson"
+            "vals": "sweep|synchronous|throughput|constant|poisson|concurrent"
         },
         "output_path": {
             "description": "The output path is provided as a parameter for completeness, but cannot be changed. This check is present in a few layers.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the allowed options for the "guidellm_rate_type" parameter to include "concurrent" as a valid value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->